### PR TITLE
Paging for VirtualMachine and VirtualNetwork

### DIFF
--- a/client/virtualmachine.go
+++ b/client/virtualmachine.go
@@ -22,7 +22,7 @@ const (
 type VirtualMachineService interface {
 	ComputeClusterList() (*[]ComputeCluster, error)
 	VirtualMachineTemplateList() (*[]VirtualMachineTemplate, error)
-	Page() (*Page, *[]VirtualMachine, error)
+	Page(request PageRequest) (*Page, *[]VirtualMachine, error)
 	Get(id string) (*VirtualMachineExt, error)
 	Create(vm *VirtualMachineCreate) (*VirtualMachineTask, error)
 	Delete(id string) (*VirtualMachineTask, error)
@@ -157,9 +157,9 @@ func (c *VirtualMachineServiceOp) VirtualMachineTemplateList() (*[]VirtualMachin
 	return virtualMachineTemplates, err
 }
 
-func (c *VirtualMachineServiceOp) Page() (*Page, *[]VirtualMachine, error) {
+func (c *VirtualMachineServiceOp) Page(request PageRequest) (*Page, *[]VirtualMachine, error) {
 	page := new(Page)
-	err := c.client.Get(iaasBasePath+"virtualmachine", page, nil)
+	err := c.client.Get(iaasBasePath+"virtualmachine", page, &request)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/client/virtualnetwork.go
+++ b/client/virtualnetwork.go
@@ -8,7 +8,7 @@ const (
 )
 
 type VirtualNetworkService interface {
-	Page() (*Page, *[]VirtualNetwork, error)
+	Page(request PageRequest) (*Page, *[]VirtualNetwork, error)
 	Get(id string) (*VirtualNetwork, error)
 	Create(vn *VirtualNetworkUpdate) (*VirtualNetworkTask, error)
 	Delete(id string) (*VirtualNetworkTask, error)
@@ -40,9 +40,9 @@ type VirtualNetworkUpdate struct {
 	Group string `json:"group,omitempty"`
 }
 
-func (c *VirtualNetworkServiceOp) Page() (*Page, *[]VirtualNetwork, error) {
+func (c *VirtualNetworkServiceOp) Page(request PageRequest) (*Page, *[]VirtualNetwork, error) {
 	page := new(Page)
-	err := c.client.Get(iaasBasePath+"virtualnetwork", page, nil)
+	err := c.client.Get(iaasBasePath+"virtualnetwork", page, &request)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/cmd/virtualmachine.go
+++ b/cmd/virtualmachine.go
@@ -75,7 +75,13 @@ func init() {
 }
 
 func list(cmd *cobra.Command, args []string) error {
-	_, content, err := previderClient.VirtualMachine.Page()
+	var page client.PageRequest
+	page.Size = 100
+	page.Page = 0
+	page.Sort = "+name"
+	page.Query = ""
+
+	_, content, err := previderClient.VirtualMachine.Page(page)
 	if err != nil {
 		fmt.Println(err)
 	}


### PR DESCRIPTION
- Added PageRequest as parameter to the list functions for virtualmachine and virtualnetwork
- previder-cli virtualmachine list now uses a PageRequest to display 100 entries by default